### PR TITLE
fix: use stdpath, hide warnings

### DIFF
--- a/lua/json-to-types/utils.lua
+++ b/lua/json-to-types/utils.lua
@@ -51,9 +51,8 @@ M.executeTypesCommand = function(file_name, target_language)
   --   .. file_name
   --   .. " > "
   --   .. types_output_file
-  local types_command = "node "
-    .. home
-    .. "/.local/share/nvim/lazy/json-to-types.nvim/quicktype.js "
+  local types_command = "node --no-warnings "
+    .. vim.fn.stdpath('data') .. "/lazy/json-to-types.nvim/quicktype.js "
     .. target_language
     .. " "
     .. file_name


### PR DESCRIPTION
This PR removed hard-coded nvim path, so errors won't be caused when not using the default nvim share directory.

Useful for nvim distros,and configurations that don't use the default directories.